### PR TITLE
Add simple multi-track recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This project provides a simple command line tool to record vocals to a WAV file.
 The time critical audio buffering is implemented in C for best performance.
 
+The package now also includes a basic multi track recorder. The
+``MultiTrackRecorder`` class allows recording multiple tracks, seeking
+within a track and mixing them for playback. Recording can optionally start
+after a countdown and supports punch‑in recording where audio is overwritten
+from the current position.
+
 ## Usage
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup, Extension
 
 ringbuffer_ext = Extension(
-    'vocals.ringbuffer',
-    sources=['src/vocals/ringbuffer/ringbuffer.c'],
+    "vocals.ringbuffer",
+    sources=["src/vocals/ringbuffer/ringbuffer.c"],
 )
 
 setup(
-    name='vocals',
-    version='0.1.0',
-    packages=['vocals'],
-    package_dir={'': 'src'},
+    name="vocals",
+    version="0.1.0",
+    packages=["vocals"],
+    package_dir={"": "src"},
     ext_modules=[ringbuffer_ext],
 )

--- a/src/vocals/__init__.py
+++ b/src/vocals/__init__.py
@@ -1,3 +1,5 @@
 """Vocals recording package."""
 
-__all__ = []
+from .multitrack import MultiTrackRecorder
+
+__all__ = ["MultiTrackRecorder"]

--- a/src/vocals/multitrack.py
+++ b/src/vocals/multitrack.py
@@ -1,0 +1,90 @@
+import time
+from typing import List
+
+import numpy as np
+
+try:
+    import sounddevice as sd
+except Exception as e:  # pragma: no cover - dependency missing in tests
+    sd = None
+
+
+class MultiTrackRecorder:
+    """Simple multi track recorder supporting seek and punch-in recording."""
+
+    def __init__(self, num_tracks: int = 2, samplerate: int = 44100, channels: int = 1):
+        self.samplerate = samplerate
+        self.channels = channels
+        self.tracks: List[np.ndarray] = [
+            np.zeros(0, dtype=np.float32) for _ in range(num_tracks)
+        ]
+        self.selected_track = 0
+        self.position = 0  # current play/record position in samples
+
+    def select_track(self, index: int) -> None:
+        """Select track index for recording and playback."""
+        if not 0 <= index < len(self.tracks):
+            raise ValueError("invalid track index")
+        self.selected_track = index
+        self.position = 0
+
+    def seek(self, seconds: float) -> None:
+        """Seek to position in seconds."""
+        if seconds < 0:
+            raise ValueError("seconds must be positive")
+        self.position = int(seconds * self.samplerate)
+        self._ensure_length(self.selected_track, self.position)
+
+    def _ensure_length(self, track_index: int, length: int) -> None:
+        track = self.tracks[track_index]
+        if len(track) < length:
+            pad = np.zeros(length - len(track), dtype=np.float32)
+            self.tracks[track_index] = np.concatenate([track, pad])
+
+    def record(
+        self, duration: float, countdown: int = 0, punch_in: bool = False
+    ) -> None:
+        """Record for ``duration`` seconds to the selected track."""
+        if sd is None:
+            raise RuntimeError("sounddevice is not available")
+        if countdown > 0:
+            for i in range(countdown, 0, -1):
+                print(i)
+                time.sleep(1)
+        frames = int(duration * self.samplerate)
+        recorded = sd.rec(
+            frames, samplerate=self.samplerate, channels=self.channels, dtype="float32"
+        )
+        sd.wait()
+        start = self.position
+        end = start + frames
+        self._ensure_length(self.selected_track, end)
+        track = self.tracks[self.selected_track]
+        track[start:end] = recorded[:, 0]
+        self.position = end
+
+    def play(self, duration: float | None = None) -> None:
+        """Play from current position for ``duration`` seconds if given."""
+        if sd is None:
+            raise RuntimeError("sounddevice is not available")
+        max_len = max(len(t) for t in self.tracks)
+        if duration is None:
+            end = max_len
+        else:
+            end = min(self.position + int(duration * self.samplerate), max_len)
+        if end <= self.position:
+            return
+        length = end - self.position
+        mix = np.zeros(length, dtype=np.float32)
+        for track in self.tracks:
+            if self.position < len(track):
+                segment = track[self.position : end]
+                mix[: len(segment)] += segment
+        sd.play(mix, samplerate=self.samplerate)
+        sd.wait()
+        self.position = end
+
+    def pause(self) -> None:
+        """Stop playback or recording."""
+        if sd is not None:
+            sd.stop()

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+from vocals.multitrack import MultiTrackRecorder
+
+
+class DummySD:
+    def __init__(self, data):
+        self.data = data
+        self.play_called = False
+
+    def rec(self, frames, samplerate=44100, channels=1, dtype="float32"):
+        assert frames == len(self.data)
+        return self.data.reshape(-1, channels)
+
+    def wait(self):
+        pass
+
+    def play(self, data, samplerate=44100):
+        self.play_called = True
+        self.play_data = data
+
+    def stop(self):
+        self.play_called = False
+
+
+def test_record_and_play(monkeypatch):
+    sd_dummy = DummySD(np.arange(4, dtype=np.float32))
+    monkeypatch.setattr("vocals.multitrack.sd", sd_dummy)
+    rec = MultiTrackRecorder(num_tracks=1, samplerate=4)
+    rec.record(duration=1)
+    assert np.allclose(rec.tracks[0], sd_dummy.data)
+    rec.seek(0)
+    rec.play()
+    assert sd_dummy.play_called
+    assert np.allclose(sd_dummy.play_data, sd_dummy.data)


### PR DESCRIPTION
## Summary
- introduce `MultiTrackRecorder` supporting multiple tracks, seeking, playback, punch‑in and countdown
- expose the new class in `vocals` package
- document the new recorder in the README
- add unit tests for the recorder

## Testing
- `python setup.py build_ext --inplace`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3cc9804c8327b90a60bc3b26ba35