### PR TITLE
Implement take library for MultiTrackRecorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ cutting, copying or pasting them between tracks for simple editing. Audio can
 be imported from WAV or MP3 files and a mix of tracks can be exported back to
 WAV or MP3.
 
+The recorder features a simple *take library*. Portions of a track can be
+selected and stored as a take. Additional takes for the same region can be
+recorded using automatic punch‑in recording and are kept together in the
+library. A stored take can be reapplied to replace the current audio for that
+selection.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- extend `MultiTrackRecorder` with a take library to store multiple takes of a track region
- add helper methods to record new takes, apply and list them
- document the take library in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `python setup.py build_ext --inplace`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d44796a5c83278e1d7f045d2dd3de