### PR TITLE
Support audible countdown for recording

### DIFF
--- a/src/vocals/multitrack.py
+++ b/src/vocals/multitrack.py
@@ -1,6 +1,8 @@
 import time
 from typing import List
 
+from . import utils
+
 import numpy as np
 
 try:
@@ -66,6 +68,8 @@ class MultiTrackRecorder:
         if countdown > 0:
             for i in range(countdown, 0, -1):
                 print(i)
+                freq = 880 if (countdown - i) % 2 == 0 else 660
+                utils.beep(freq, samplerate=self.samplerate)
                 time.sleep(1)
 
         frames = int(duration * self.samplerate)

--- a/src/vocals/record.py
+++ b/src/vocals/record.py
@@ -2,6 +2,8 @@ import argparse
 import time
 import numpy as np
 
+from . import utils
+
 try:
     import sounddevice as sd
 except Exception as e:
@@ -13,10 +15,23 @@ except Exception as e:
     raise SystemExit("ringbuffer extension not built: %s" % e)
 
 
-def record_to_file(filename, duration=5, samplerate=44100, channels=1):
+def record_to_file(
+    filename,
+    duration=5,
+    samplerate=44100,
+    channels=1,
+    countdown=0,
+):
     """Record audio from the default microphone and save to a WAV file."""
     buffer = ringbuffer.RingBuffer(int(samplerate * channels))
     recorded = []
+
+    if countdown > 0:
+        for i in range(countdown, 0, -1):
+            print(i)
+            freq = 880 if (countdown - i) % 2 == 0 else 660
+            utils.beep(freq, samplerate=samplerate)
+            time.sleep(1)
 
     def callback(indata, frames, time_info, status):
         written = buffer.write(indata.astype("float32").ravel())
@@ -50,8 +65,15 @@ def main():
         "-d", "--duration", type=float, default=5, help="Duration in seconds"
     )
     parser.add_argument("-r", "--rate", type=int, default=44100, help="Sample rate")
+    parser.add_argument(
+        "-c",
+        "--countdown",
+        type=int,
+        default=0,
+        help="Countdown in seconds before recording starts",
+    )
     args = parser.parse_args()
-    record_to_file(args.outfile, args.duration, args.rate)
+    record_to_file(args.outfile, args.duration, args.rate, countdown=args.countdown)
 
 
 if __name__ == "__main__":

--- a/src/vocals/utils.py
+++ b/src/vocals/utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+try:
+    import sounddevice as sd
+except Exception:  # pragma: no cover - dependency missing in tests
+    sd = None
+
+
+def beep(frequency: float, samplerate: int = 44100, duration: float = 0.2) -> None:
+    """Play a short beep of ``frequency`` Hz using ``sounddevice``."""
+    if sd is None:
+        return
+    t = np.linspace(0, duration, int(samplerate * duration), False)
+    tone = np.sin(2 * np.pi * frequency * t).astype(np.float32)
+    sd.play(tone, samplerate=samplerate)
+    sd.wait()

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -105,6 +105,11 @@ def test_countdown_with_playback(monkeypatch):
 
     sleeps = []
     monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+    beeps = []
+    monkeypatch.setattr(
+        "vocals.multitrack.utils.beep",
+        lambda freq, samplerate=44100, duration=0.2: beeps.append(freq),
+    )
 
     rec = MultiTrackRecorder(num_tracks=2, samplerate=4)
     rec.tracks[0] = np.array([1, 1, 1, 1], dtype=np.float32)
@@ -112,4 +117,5 @@ def test_countdown_with_playback(monkeypatch):
     rec.record(duration=1, countdown=2, play_tracks=[0])
 
     assert sleeps == [1, 1]
+    assert beeps == [880, 660]
     assert np.allclose(sd_dummy.play_data[:, 0], rec.tracks[0])


### PR DESCRIPTION
## Summary
- add utility to play short beep sounds
- support configurable countdown in `record_to_file`
- play alternating beep tones during countdown in `MultiTrackRecorder.record`
- check countdown tones in tests

All tests pass.


------
https://chatgpt.com/codex/tasks/task_e_687d45c762088327b65abceac10a26c0