### PR TITLE
Add metronome support for vocalists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ recorded using automatic punch‑in recording and are kept together in the
 library. A stored take can be reapplied to replace the current audio for that
 selection.
 
+The ``record`` method now accepts a ``metronome_bpm`` argument to play a click
+track while recording. The command line ``record`` tool also supports a
+``--bpm`` option so vocalists can keep time even when no other tracks are
+available.
+
 ## Usage
 
 ```bash

--- a/src/vocals/utils.py
+++ b/src/vocals/utils.py
@@ -6,11 +6,21 @@ except Exception:  # pragma: no cover - dependency missing in tests
     sd = None
 
 
+def beep_sound(
+    frequency: float, samplerate: int = 44100, duration: float = 0.2
+) -> np.ndarray:
+    """Return a sine wave beep of ``frequency`` Hz."""
+
+    t = np.linspace(0, duration, int(samplerate * duration), False)
+    return np.sin(2 * np.pi * frequency * t).astype(np.float32)
+
+
 def beep(frequency: float, samplerate: int = 44100, duration: float = 0.2) -> None:
     """Play a short beep of ``frequency`` Hz using ``sounddevice``."""
+
     if sd is None:
         return
-    t = np.linspace(0, duration, int(samplerate * duration), False)
-    tone = np.sin(2 * np.pi * frequency * t).astype(np.float32)
+
+    tone = beep_sound(frequency, samplerate=samplerate, duration=duration)
     sd.play(tone, samplerate=samplerate)
     sd.wait()

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -40,6 +40,24 @@ def test_record_and_play(monkeypatch):
     assert np.allclose(sd_dummy.play_data, sd_dummy.data)
 
 
+def test_record_with_metronome(monkeypatch):
+    record_data = np.zeros(10, dtype=np.float32)
+    sd_dummy = DummySD(record_data)
+    monkeypatch.setattr("vocals.multitrack.sd", sd_dummy)
+    monkeypatch.setattr(
+        "vocals.multitrack.utils.beep_sound",
+        lambda *a, **k: np.ones(3, dtype=np.float32),
+    )
+
+    rec = MultiTrackRecorder(num_tracks=1, samplerate=10)
+    rec.record(duration=1, metronome_bpm=120)
+
+    expected = np.zeros((10, 1), dtype=np.float32)
+    expected[0:3, 0] += 1
+    expected[5:8, 0] += 1
+    assert np.allclose(sd_dummy.play_data, expected)
+
+
 def test_copy_paste_between_tracks():
     rec = MultiTrackRecorder(num_tracks=2, samplerate=1)
     rec.tracks[0] = np.array([1, 2, 3, 4], dtype=np.float32)


### PR DESCRIPTION
## Summary
- allow generating beep sound arrays
- add optional metronome in `MultiTrackRecorder.record`
- support metronome in `record` CLI tool via `--bpm`
- document feature in README
- test metronome playback in `MultiTrackRecorder`

## Testing
- `python setup.py build_ext --inplace`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d474ff54883278d60b0901b71a8e1