### PR TITLE
Add pitch analysis helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ recorded using automatic punch‑in recording and are kept together in the
 library. A stored take can be reapplied to replace the current audio for that
 selection.
 
+The ``vocals.utils`` module now provides simple pitch analysis helpers. A
+recorded track's pitch range can be inspected using
+``MultiTrackRecorder.pitch_range``. This helps vocalists monitor the lowest and
+highest notes they hit during a take.
+
 The ``record`` method now accepts a ``metronome_bpm`` argument to play a click
 track while recording. The command line ``record`` tool also supports a
 ``--bpm`` option so vocalists can keep time even when no other tracks are

--- a/src/vocals/__init__.py
+++ b/src/vocals/__init__.py
@@ -1,5 +1,6 @@
 """Vocals recording package."""
 
 from .multitrack import MultiTrackRecorder
+from .utils import estimate_pitch, pitch_range
 
-__all__ = ["MultiTrackRecorder"]
+__all__ = ["MultiTrackRecorder", "estimate_pitch", "pitch_range"]

--- a/src/vocals/multitrack.py
+++ b/src/vocals/multitrack.py
@@ -338,3 +338,15 @@ class MultiTrackRecorder:
             duration, countdown=countdown, punch_in=True, play_tracks=play_tracks
         )
         self.add_selection_to_library()
+
+    def pitch_range(self, track_index: int | None = None) -> tuple[float, float] | None:
+        """Return the pitch range of ``track_index`` using ``utils.pitch_range``."""
+
+        if track_index is None:
+            track_index = self.selected_track
+        if not 0 <= track_index < len(self.tracks):
+            raise ValueError("invalid track index")
+
+        samples = self.tracks[track_index]
+        result = utils.pitch_range(samples, samplerate=self.samplerate)
+        return result

--- a/src/vocals/utils.py
+++ b/src/vocals/utils.py
@@ -24,3 +24,49 @@ def beep(frequency: float, samplerate: int = 44100, duration: float = 0.2) -> No
     tone = beep_sound(frequency, samplerate=samplerate, duration=duration)
     sd.play(tone, samplerate=samplerate)
     sd.wait()
+
+
+def estimate_pitch(samples: np.ndarray, samplerate: int = 44100) -> float | None:
+    """Estimate fundamental frequency of ``samples`` using auto-correlation."""
+
+    if samples.ndim > 1:
+        samples = samples[:, 0]
+
+    samples = samples.astype(np.float32, copy=False)
+    samples = samples - np.mean(samples)
+    if np.max(np.abs(samples)) < 1e-3:
+        return None
+
+    corr = np.correlate(samples, samples, mode="full")
+    corr = corr[len(corr) // 2 :]
+    d = np.diff(corr)
+    positive = np.where(d > 0)[0]
+    if positive.size == 0:
+        return None
+    start = positive[0]
+    peak = start + np.argmax(corr[start:])
+    if peak == 0:
+        return None
+    return float(samplerate) / float(peak)
+
+
+def pitch_range(
+    samples: np.ndarray, samplerate: int = 44100, frame_size: int = 2048
+) -> tuple[float, float] | None:
+    """Return estimated min and max pitch for ``samples``."""
+
+    if samples.ndim > 1:
+        samples = samples[:, 0]
+
+    pitches: list[float] = []
+    hop = frame_size // 2
+    for i in range(0, len(samples) - frame_size, hop):
+        frame = samples[i : i + frame_size]
+        pitch = estimate_pitch(frame, samplerate)
+        if pitch is not None:
+            pitches.append(pitch)
+
+    if not pitches:
+        return None
+
+    return min(pitches), max(pitches)

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -137,3 +137,15 @@ def test_countdown_with_playback(monkeypatch):
     assert sleeps == [1, 1]
     assert beeps == [880, 660]
     assert np.allclose(sd_dummy.play_data[:, 0], rec.tracks[0])
+
+
+def test_pitch_range_method():
+    sr = 8000
+    rec = MultiTrackRecorder(num_tracks=1, samplerate=sr)
+    t = np.linspace(0, 1, sr, False)
+    part1 = np.sin(2 * np.pi * 220 * t[: sr // 2])
+    part2 = np.sin(2 * np.pi * 440 * t[: sr // 2])
+    rec.tracks[0] = np.concatenate([part1, part2]).astype(np.float32)
+    low, high = rec.pitch_range()
+    assert low == pytest.approx(220, rel=0.05)
+    assert high == pytest.approx(440, rel=0.05)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+
+from vocals import utils
+
+
+def test_estimate_pitch():
+    samplerate = 8000
+    t = np.linspace(0, 1, samplerate, False)
+    tone = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    pitch = utils.estimate_pitch(tone, samplerate=samplerate)
+    assert pitch == pytest.approx(440, rel=0.02)
+
+
+def test_pitch_range():
+    samplerate = 8000
+    t = np.linspace(0, 1, samplerate, False)
+    tone_low = np.sin(2 * np.pi * 220 * t[: samplerate // 2])
+    tone_high = np.sin(2 * np.pi * 660 * t[: samplerate // 2])
+    samples = np.concatenate([tone_low, tone_high]).astype(np.float32)
+    low, high = utils.pitch_range(samples, samplerate=samplerate)
+    assert low == pytest.approx(220, rel=0.05)
+    assert high == pytest.approx(660, rel=0.05)


### PR DESCRIPTION
## Summary
- add new functions `estimate_pitch` and `pitch_range`
- expose the pitch helpers via the package API
- let `MultiTrackRecorder` report pitch range
- document pitch analysis helpers
- add tests for new utilities and methods

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `python setup.py build_ext --inplace`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d493b58988327b4b0c10db7ae09d1