### PR TITLE
Add warmup and pitch range features

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ track while recording. The command line ``record`` tool also supports a
 ``--bpm`` option so vocalists can keep time even when no other tracks are
 available.
 
+When using ``python -m vocals.record`` the ``--show-range`` flag will print the
+detected pitch range of the take once recording finishes. Additionally the
+``vocals.warmup`` module can play a simple ascending and descending scale to
+help warm up the voice:
+
+```bash
+python -m vocals.warmup
+```
+
 ## Usage
 
 ```bash

--- a/src/vocals/record.py
+++ b/src/vocals/record.py
@@ -22,6 +22,7 @@ def record_to_file(
     channels=1,
     countdown=0,
     metronome_bpm=None,
+    show_range=False,
 ):
     """Record audio from the default microphone and save to a WAV file."""
     buffer = ringbuffer.RingBuffer(int(samplerate * channels))
@@ -77,6 +78,12 @@ def record_to_file(
         wf.setframerate(samplerate)
         wf.writeframes((data * 32767).astype("<i2").tobytes())
 
+    if show_range and len(data) > 0:
+        result = utils.pitch_range(data, samplerate=samplerate)
+        if result is not None:
+            low, high = result
+            print(f"Pitch range: {low:.1f} Hz - {high:.1f} Hz")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Record vocals to a WAV file")
@@ -98,6 +105,11 @@ def main():
         default=None,
         help="Play a metronome click at this tempo while recording",
     )
+    parser.add_argument(
+        "--show-range",
+        action="store_true",
+        help="Print detected pitch range after recording",
+    )
     args = parser.parse_args()
     record_to_file(
         args.outfile,
@@ -105,6 +117,7 @@ def main():
         args.rate,
         countdown=args.countdown,
         metronome_bpm=args.bpm,
+        show_range=args.show_range,
     )
 
 

--- a/src/vocals/warmup.py
+++ b/src/vocals/warmup.py
@@ -1,0 +1,44 @@
+import argparse
+import math
+
+from . import utils
+
+
+def warmup(
+    start_freq: float = 220.0,
+    steps: int = 8,
+    duration: float = 0.5,
+    up_down: bool = True,
+) -> None:
+    """Play a warmup scale to help singers get ready."""
+
+    freqs = [start_freq * math.pow(2, i / 12) for i in range(steps)]
+    if up_down and steps > 1:
+        freqs += freqs[-2::-1]
+    for f in freqs:
+        utils.beep(f, duration=duration)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Play a simple warmup scale")
+    parser.add_argument(
+        "--start", type=float, default=220.0, help="Starting frequency in Hz"
+    )
+    parser.add_argument("--steps", type=int, default=8, help="Number of semitone steps")
+    parser.add_argument(
+        "--duration", type=float, default=0.5, help="Beep duration in seconds"
+    )
+    parser.add_argument(
+        "--no-down", action="store_true", help="Don't descend back to the start"
+    )
+    args = parser.parse_args()
+    warmup(
+        start_freq=args.start,
+        steps=args.steps,
+        duration=args.duration,
+        up_down=not args.no_down,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1,0 +1,63 @@
+import numpy as np
+import importlib
+import sys
+import types
+
+
+class DummyBuffer:
+    def __init__(self, size):
+        self.data = []
+
+    def write(self, arr):
+        self.data.extend(arr)
+        return len(arr)
+
+    def read(self, n):
+        out = self.data[:n]
+        self.data = self.data[n:]
+        return np.array(out, dtype=np.float32).tobytes()
+
+
+class DummyStream:
+    def __init__(self, data, callback):
+        self.data = data.reshape(-1, 1)
+        self.callback = callback
+
+    def __enter__(self):
+        self.callback(self.data, len(self.data), None, None)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySD:
+    def __init__(self, data, samplerate):
+        self.data = data
+        self.samplerate = samplerate
+
+    def InputStream(self, channels=1, samplerate=44100, callback=None):
+        assert samplerate == self.samplerate
+        return DummyStream(self.data, callback)
+
+    def sleep(self, ms):
+        pass
+
+
+def test_record_prints_range(tmp_path, monkeypatch, capsys):
+    data = np.sin(2 * np.pi * 440 * np.linspace(0, 1, 10, False)).astype(np.float32)
+
+    sd_stub = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "sounddevice", sd_stub)
+    record = importlib.import_module("vocals.record")
+
+    sd_dummy = DummySD(data, 10)
+    monkeypatch.setattr(record, "sd", sd_dummy)
+    monkeypatch.setattr(record.ringbuffer, "RingBuffer", lambda size: DummyBuffer(size))
+    monkeypatch.setattr(
+        record.utils, "pitch_range", lambda samples, samplerate=10: (430.0, 450.0)
+    )
+    outfile = tmp_path / "out.wav"
+    record.record_to_file(str(outfile), duration=1, samplerate=10, show_range=True)
+    captured = capsys.readouterr().out
+    assert "Pitch range" in captured

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,14 @@
+import numpy as np
+from vocals import warmup
+
+
+def test_warmup_beeps(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "vocals.warmup.utils.beep",
+        lambda freq, duration=0.5, samplerate=44100: calls.append(freq),
+    )
+    warmup.warmup(start_freq=100, steps=3, duration=0.1)
+    semitone = 2 ** (1 / 12)
+    expected = [100, 100 * semitone, 100 * (semitone**2), 100 * semitone, 100]
+    assert [round(f, 3) for f in calls] == [round(f, 3) for f in expected]


### PR DESCRIPTION
## Summary
- introduce `warmup` module with simple scale playback
- print pitch range of takes via `--show-range` flag
- test new warmup and recording helpers

## Testing
- `pip install -e .`
- `python setup.py build_ext --inplace`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4ab289908327836271a2868d74f6