### PR TITLE
Add note detection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ available.
 The ``record`` command also has a ``--reference`` option to play a short
 reference note before recording begins. Notes can be given as a frequency or a
 note name like ``A4`` which is converted using ``vocals.utils.note_to_freq``.
+The ``vocals.utils.freq_to_note`` helper performs the reverse conversion and
+can be used to display the nearest note for a detected pitch.
 
 When using ``python -m vocals.record`` the ``--show-range`` flag will print the
 detected pitch range of the take once recording finishes. Additionally the

--- a/src/vocals/__init__.py
+++ b/src/vocals/__init__.py
@@ -1,6 +1,12 @@
 """Vocals recording package."""
 
 from .multitrack import MultiTrackRecorder
-from .utils import estimate_pitch, note_to_freq, pitch_range
+from .utils import estimate_pitch, note_to_freq, pitch_range, freq_to_note
 
-__all__ = ["MultiTrackRecorder", "estimate_pitch", "pitch_range", "note_to_freq"]
+__all__ = [
+    "MultiTrackRecorder",
+    "estimate_pitch",
+    "pitch_range",
+    "note_to_freq",
+    "freq_to_note",
+]

--- a/src/vocals/utils.py
+++ b/src/vocals/utils.py
@@ -116,3 +116,29 @@ def pitch_range(
         return None
 
     return min(pitches), max(pitches)
+
+
+def freq_to_note(freq: float) -> str:
+    """Return the closest note name for ``freq`` in Hz."""
+
+    if freq <= 0:
+        raise ValueError("frequency must be positive")
+
+    semitones = round(12 * np.log2(freq / 440.0))
+    note_index = (semitones + 9) % 12
+    octave = 4 + (semitones + 9) // 12
+    names = [
+        "C",
+        "C#",
+        "D",
+        "D#",
+        "E",
+        "F",
+        "F#",
+        "G",
+        "G#",
+        "A",
+        "A#",
+        "B",
+    ]
+    return f"{names[note_index]}{octave}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,3 +26,8 @@ def test_pitch_range():
 def test_note_to_freq():
     assert utils.note_to_freq("A4") == pytest.approx(440.0, rel=0.001)
     assert utils.note_to_freq("C4") == pytest.approx(261.63, rel=0.01)
+
+
+def test_freq_to_note():
+    assert utils.freq_to_note(440.0) == "A4"
+    assert utils.freq_to_note(261.63) == "C4"


### PR DESCRIPTION
## Summary
- add `freq_to_note` helper to convert frequencies to note names
- expose the helper in the public package
- mention the helper in the README
- test the new functionality

## Testing
- `python setup.py build_ext --inplace`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d4f9f8a088327a9012308dcbd7f38